### PR TITLE
Allow `authGSSClientInit` principal kwarg to be None.

### DIFF
--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -150,7 +150,7 @@ static PyObject* authGSSClientInit(PyObject* self, PyObject* args, PyObject* key
     int result = 0;
 
     if (! PyArg_ParseTupleAndKeywords(
-        args, keywds, "s|slOO", kwlist,
+        args, keywds, "s|zlOO", kwlist,
         &service, &principal, &gss_flags, &pydelegatestate, &pymech_oid
     )) {
         return NULL;


### PR DESCRIPTION
This PR simply applies the patch from https://github.com/apple/ccs-pykerberos/issues/49 for easier merging.

Fixes #49
