### PR TITLE
Cbt support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,59 @@ not offer any protection against possible KDC spoofing. That method should not b
 production code.
 
 
+Channel Bindings
+================
+
+You can use this library to authenticate with Channel Binding support. Channel
+Bindings are tags that identify the particular data channel being used with the
+authentication. You can use Channel bindings to offer more proof of a valid
+identity. Some services like Microsoft's Extended Protection can enforce
+Channel Binding support on authorisation and you can use this library to meet
+those requirements.
+
+More details on Channel Bindings as set through the GSSAPI can be found here
+<https://docs.oracle.com/cd/E19455-01/806-3814/overview-52/index.html>. Using
+TLS as a example this is how you would add Channel Binding support to your
+authentication mechanism. The following code snippet is based on RFC5929
+<https://tools.ietf.org/html/rfc5929> using the 'tls-server-endpoint-point'
+type.
+
+.. code-block:: python
+
+   import hashlib
+
+    def get_channel_bindings_application_data(socket):
+        # This is a highly simplified example, there are other use cases
+        # where you might need to use different hash types or get a socket
+        # object somehow.
+        server_certificate = socket.getpeercert(True)
+        certificate_hash = hashlib.sha256(server_certificate).hexdigest().upper()
+        certificate_digest = base64.b16decode(certificate_hash)
+        application_data = b'tls-server-end-point:%s' % certificate_digest
+
+        return application_data
+
+    def main():
+        # Code to setup a socket with the server
+        # A lot of code to setup the handshake and start the auth process
+        socket = getsocketsomehow()
+
+        # Connect to the host and start the auth process
+
+        # Build the channel bindings object
+        application_data = get_channel_bindings_application_data(socket)
+        channel_bindings = kerberos.channelBindings(application_data=application_data)
+
+        # More work to get responses from the server
+
+        result, context = kerberos.authGSSClientInit(kerb_spn, gssflags=gssflags, principal=principal)
+
+        # Pass through the channel_bindings object as created in the kerberos.channelBindings method
+        result = kerberos.authGSSClientStep(context, neg_resp_value, channel_bindings=channel_bindings)
+
+        # Repeat as necessary
+
+
 Python APIs
 ===========
 

--- a/pysrc/kerberos.py
+++ b/pysrc/kerberos.py
@@ -193,7 +193,69 @@ def authGSSClientInquireCred(context):
 
 
 
-def authGSSClientStep(context, challenge):
+"""
+Address Types for Channel Bindings
+https://docs.oracle.com/cd/E19455-01/806-3814/6jcugr7dp/index.html#reference-9
+
+"""
+
+GSS_C_AF_UNSPEC    = 0
+GSS_C_AF_LOCAL     = 1
+GSS_C_AF_INET      = 2
+GSS_C_AF_IMPLINK   = 3
+GSS_C_AF_PUP       = 4
+GSS_C_AF_CHAOS     = 5
+GSS_C_AF_NS        = 6
+GSS_C_AF_NBS       = 7
+GSS_C_AF_ECMA      = 8
+GSS_C_AF_DATAKIT   = 9
+GSS_C_AF_CCITT     = 10
+GSS_C_AF_SNA       = 11
+GSS_C_AF_DECnet    = 12
+GSS_C_AF_DLI       = 13
+GSS_C_AF_LAT       = 14
+GSS_C_AF_HYLINK    = 15
+GSS_C_AF_APPLETALK = 16
+GSS_C_AF_BSC       = 17
+GSS_C_AF_DSS       = 18
+GSS_C_AF_OSI       = 19
+GSS_C_AF_X25       = 21
+GSS_C_AF_NULLADDR  = 255
+
+
+
+def channelBindings(**kwargs):
+    """
+    Builds a gss_channel_bindings_struct which can be used to pass onto
+    L{authGSSClientStep} to bind onto the auth. Details on Channel Bindings
+    can be foud at https://tools.ietf.org/html/rfc5929. More details on the
+    struct can be found at
+    https://docs.oracle.com/cd/E19455-01/806-3814/overview-52/index.html
+
+    @param initiator_addrtype: Optional integer used to set the
+        initiator_addrtype, defaults to GSS_C_AF_UNSPEC if not set
+
+    @param initiator_address: Optional byte string containing the
+        initiator_address
+
+    @param acceptor_addrtype: Optional integer used to set the
+        acceptor_addrtype, defaults to GSS_C_AF_UNSPEC if not set
+
+    @param acceptor_address: Optional byte string containing the
+        acceptor_address
+
+    @param application_data: Optional byte string containing the
+        application_data. An example would be 'tls-server-end-point:{cert-hash}'
+        where {cert-hash} is the hash of the server's certificate
+
+    @return: A tuple of (result, gss_channel_bindings_struct) where result is
+        the result code and gss_channel_bindings_struct is the channel bindings
+        structure that can be passed onto L{authGSSClientStep}
+    """
+
+
+
+def authGSSClientStep(context, challenge, **kwargs):
     """
     Processes a single GSSAPI client-side step using the supplied server data.
 
@@ -201,6 +263,11 @@ def authGSSClientStep(context, challenge):
 
     @param challenge: A string containing the base64-encoded server data (which
         may be empty for the first step).
+
+    @param channel_bindings: Optional channel bindings to bind onto the auth
+        request. This struct can be built using :{channelBindings}
+        and if not specified it will pass along GSS_C_NO_CHANNEL_BINDINGS as
+        a default.
 
     @return: A result code (see above).
     """

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except ImportError:
 
 project_name = "kerberos"
 
-version_string = "1.2.6"
+version_string = "1.3.0"
 
 description = "Kerberos high-level interface"
 

--- a/src/kerberosgss.c
+++ b/src/kerberosgss.c
@@ -232,7 +232,7 @@ int authenticate_gss_client_clean(gss_client_state *state)
 }
 
 int authenticate_gss_client_step(
-    gss_client_state* state, const char* challenge
+    gss_client_state* state, const char* challenge, struct gss_channel_bindings_struct* channel_bindings
 ) {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
@@ -269,7 +269,7 @@ int authenticate_gss_client_step(
         state->mech_oid,
         (OM_uint32)state->gss_flags,
         0,
-        GSS_C_NO_CHANNEL_BINDINGS,
+        channel_bindings,
         &input_token,
         NULL,
         &output_token,

--- a/src/kerberosgss.h
+++ b/src/kerberosgss.h
@@ -61,7 +61,7 @@ int authenticate_gss_client_clean(
     gss_client_state *state
 );
 int authenticate_gss_client_step(
-    gss_client_state *state, const char *challenge
+    gss_client_state *state, const char *challenge, struct gss_channel_bindings_struct *channel_bindings
 );
 int authenticate_gss_client_unwrap(
     gss_client_state* state, const char* challenge


### PR DESCRIPTION
Added support for creating an input channel bindings value and passing that into the authGSSClientStep as an optional argument. Will continue on with the default behavior if this isn't specified.

I'm fairly new to C so happy to take any pointers and ideas on ways this could be better improved. I've tested this manually on an IIS and WinRM endpoint where the channel bindings token is set to required and verified it worked.

# Test Result:

This is the environment set up I had to verify the test results, please ask me any questions around it or if you know of a better way to add automated tests.

## Windows Configuration

Run this script on a Server 2008 or newer host that is hooked up to a domain https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1. This will set up a WinRM listener over HTTPS with a self signed cert and open and firewall rules

After running this run the following command in Powershell to set the CBT policy to Strict

```ps
Set-Item -Path "WSMan:\localhost\Service\Auth\CbtHardeningLevel" -Value Strict
```

You can verify the setting by running this in powershell

```ps
winrm get winrm/config/service/auth

Auth
    Basic = true
    Kerberos = true
    Negotiate = true
    Certificate = false
    CredSSP = false
    CbtHardeningLevel = Strict
```

## Python Host Config

On the *nix server you are using for testing run the following command to install the relevant libraries and set everything up

```bash
pip install pywinrm
pip install git+https://github.com/jborean93/requests-kerberos@add-cbt
git clone https://github.com/jborean93/ccs-pykerberos.git
cd ccs-pykerberos
git checkout cbt-support
pip install .
```

Create the python script below

```python
from winrm.protocol import Protocol

p = Protocol(
    endpoint='https://host-fqdnl:5986/wsman',
    transport='kerberos',
    server_cert_validation='ignore'
)
shell_id = p.open_shell()
command_id = p.run_command(shell_id, 'ipconfig', ['/all'])
std_out, std_err, status_code = p.get_command_output(shell_id, command_id)
p.cleanup_command(shell_id, command_id)
p.close_shell(shell_id)

print("Return Code: {0}".format(status_code))
print("STDOUT: {0}".format(std_out))
print("STDERR: {0}".format(std_err))
```

Run the following commands to get a kerberos ticket and test out the script

```bash
kinit user@REALM.COM
python test-winrm.py
```
You get the Windows IP configuration returned

![image](https://cloud.githubusercontent.com/assets/8462645/24911317/d80735ee-1f0d-11e7-941d-1fdc73e9252d.png)

If you are using the stock standard kerberos and requests-kerberos library you would get the following error returned

![image](https://cloud.githubusercontent.com/assets/8462645/24910930/afafd124-1f0c-11e7-8daa-0846f8c2392d.png)
