### PR TITLE
more fixes for set -e

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -60,7 +60,10 @@ apt-get \
     libbz2-dev
 
 echo "Creating KDC database"
+# krb5_newrealm returns non-0 return code as it is running in a container, ignore it for this command only
+set +e
 printf "$KERBEROS_PASSWORD\n$KERBEROS_PASSWORD" | krb5_newrealm
+set -e
 
 echo "Creating principals for tests"
 kadmin.local -q "addprinc -pw $KERBEROS_PASSWORD $KERBEROS_USERNAME"


### PR DESCRIPTION
I don't see a way to re-open a PR that has already been merged, so fixing the over-eager merge of the previous PR with this brand new PR taken from the latest commit on @jborean93's fork.

When shell scripts have "set -e" to exit anytime something exits unclean, there may be times when the thing you're doing is expected to exit non-zero. In these times, bracket that activity something like: "set +e ; ... ; set -e".