### PR TITLE
Use destructors to free client and server state

### DIFF
--- a/pysrc/kerberos.py
+++ b/pysrc/kerberos.py
@@ -169,8 +169,9 @@ def authGSSClientInit(service, **kwargs):
 
 def authGSSClientClean(context):
     """
-    Destroys the context for GSSAPI client-side authentication. After this call
-    the context object is invalid and should not be used again.
+    Destroys the context for GSSAPI client-side authentication. This function
+    is provided for compatibility with earlier versions of PyKerberos but does
+    nothing. The context object destroys itself when it is reclaimed.
 
     @param context: The context object returned from L{authGSSClientInit}.
 
@@ -362,8 +363,9 @@ def authGSSServerInit(service):
 
 def authGSSServerClean(context):
     """
-    Destroys the context for GSSAPI server-side authentication.
-    After this call the context object is invalid and should not be used again.
+    Destroys the context for GSSAPI server-side authentication. This function
+    is provided for compatibility with earlier versions of PyKerberos but does
+    nothing. The context object destroys itself when it is reclaimed.
 
     @param context: The context object returned from L{authGSSClientInit}.
 


### PR DESCRIPTION
This change obsoletes the functions authGSSClientClean and
authGSSServerClean. The client and server state are now
destroyed when the PyCapsule / PyCObject storing them are
reclaimed. The functions remain to avoid breaking backward
compatibility, but just return AUTH_GSS_COMPLETE.

Resolves #48.

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
