### PR TITLE
Fix gss_server_state cast

### DIFF
--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -504,7 +504,7 @@ destroy_gss_server(PyObject *obj) {
     gss_server_state *state = PyCapsule_GetPointer(obj, NULL);
 #else
 destroy_gss_server(void *obj) {
-    gss_server_state *state = (gss_client_state *)obj;
+    gss_server_state *state = (gss_server_state *)obj;
 #endif
     if (state) {
         authenticate_gss_server_clean(state);


### PR DESCRIPTION
While testing builds of master I discovered that I got this cast wrong. 

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
