### PR TITLE
travis: Run tests on newer Python versions

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -131,7 +131,7 @@ else
 fi
 
 echo "Downloading Python $PYENV"
-wget -q "https://www.python.org/ftp/python/$PYENV/Python-$PYENV.tgz"
+wget -q "https://www.python.org/ftp/python/${PYENV%[ab]*}/Python-$PYENV.tgz"
 tar xzf "Python-$PYENV.tgz"
 cd "Python-$PYENV"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ dist: trusty
 matrix:
   include:
   - env: PYENV=2.6
-  - env: PYENV=2.7.13
-  - env: PYENV=3.4.6
-  - env: PYENV=3.5.3
-  - env: PYENV=3.6.1
-  - env: PYENV=3.7.0
+  - env: PYENV=2.7.18
+  - env: PYENV=3.4.10
+  - env: PYENV=3.5.9
+  - env: PYENV=3.6.10
+  - env: PYENV=3.7.7
+  - env: PYENV=3.8.3
+  - env: PYENV=3.9.0b3
 
 script:
 - >


### PR DESCRIPTION
Update currently listed Python versions to the newest releases, and add new releases up to 3.9.0b3.