### PR TITLE
Verify init_creds when verifying user

### DIFF
--- a/src/kerberosbasic.c
+++ b/src/kerberosbasic.c
@@ -146,6 +146,17 @@ static krb5_error_code verify_krb5_user(
         free(name);
     }
 
+    ret = krb5_verify_init_creds(context,
+            &creds,
+            server,
+            NULL,
+            NULL,
+            NULL);
+    if (ret) {
+        set_basicauth_error(context, ret);
+        goto end;
+    }
+
     krb5_get_init_creds_opt_init(&gic_options);
     ret = krb5_get_init_creds_password(
         context, &creds, principal, (char *)password,

--- a/src/kerberosbasic.c
+++ b/src/kerberosbasic.c
@@ -146,22 +146,18 @@ static krb5_error_code verify_krb5_user(
         free(name);
     }
 
-    ret = krb5_verify_init_creds(context,
-            &creds,
-            server,
-            NULL,
-            NULL,
-            NULL);
-    if (ret) {
-        set_basicauth_error(context, ret);
-        goto end;
-    }
-
     krb5_get_init_creds_opt_init(&gic_options);
     ret = krb5_get_init_creds_password(
         context, &creds, principal, (char *)password,
         NULL, NULL, 0, NULL, &gic_options
     );
+    if (ret) {
+        set_basicauth_error(context, ret);
+        goto end;
+    }
+
+    ret = krb5_verify_init_creds(context, &creds, server, NULL, NULL, NULL);
+    /* If we couldn't verify credentials against keytab, return error */
     if (ret) {
         set_basicauth_error(context, ret);
         goto end;

--- a/src/kerberospw.c
+++ b/src/kerberospw.c
@@ -58,13 +58,14 @@ static krb5_error_code verify_krb5_user(
 #endif
 
     /* Get principal name from service name */
-    ret = krb5_sname_to_principal(context, NULL, service, KRB5_NT_SRV_HST,
+    code = krb5_sname_to_principal(context, NULL, service, KRB5_NT_SRV_HST,
 				   &server);
-    if(ret) {
+    if(code) {
+        set_pwchange_error(context, code);
         goto end;
     }
 
-    ret = krb5_verify_init_creds(context,
+    code = krb5_verify_init_creds(context,
             creds,
             server,
             NULL,
@@ -72,7 +73,8 @@ static krb5_error_code verify_krb5_user(
             NULL);
     krb5_free_principal(context, server);
     /* If we couldn't verify credentials against keytab, return error */
-    if(ret) {
+    if(code) {
+        set_pwchange_error(context, code);
         goto end;
     }
 

--- a/src/kerberospw.c
+++ b/src/kerberospw.c
@@ -65,12 +65,7 @@ static krb5_error_code verify_krb5_user(
         goto end;
     }
 
-    code = krb5_verify_init_creds(context,
-            creds,
-            server,
-            NULL,
-            NULL,
-            NULL);
+    code = krb5_verify_init_creds(context, creds, server, NULL, NULL, NULL);
     krb5_free_principal(context, server);
     /* If we couldn't verify credentials against keytab, return error */
     if(code) {

--- a/src/kerberospw.c
+++ b/src/kerberospw.c
@@ -44,7 +44,8 @@ static krb5_error_code verify_krb5_user(
     krb5_get_init_creds_opt gic_options;
     krb5_error_code code;
     int ret = 0;
-    
+    krb5_principal server;
+
 #ifdef PRINTFS
     {
         char *name = NULL;
@@ -55,6 +56,25 @@ static krb5_error_code verify_krb5_user(
         free(name);
     }
 #endif
+
+    /* Get principal name from service name */
+    ret = krb5_sname_to_principal(context, NULL, service, KRB5_NT_SRV_HST,
+				   &server);
+    if(ret) {
+        goto end;
+    }
+
+    ret = krb5_verify_init_creds(context,
+            creds,
+            server,
+            NULL,
+            NULL,
+            NULL);
+    krb5_free_principal(context, server);
+    /* If we couldn't verify credentials against keytab, return error */
+    if(ret) {
+        goto end;
+    }
 
     krb5_get_init_creds_opt_init(&gic_options);
     krb5_get_init_creds_opt_set_forwardable(&gic_options, 0);


### PR DESCRIPTION
When calling function `verify_krb5_user` also verify init_creds via function `krb5_verify_init_creds`. This verifies credentials agains the system's keytab.

The verification options are set to NULL, so if the system doesn't have `verify_ap_req_nofail = true` in `/etc/krb5.conf` this change should not affect any existing workflows, but adds the option to verify init_creds for those who might want/need it.