### PR TITLE
Use Py_ssize_t type

### DIFF
--- a/src/kerberos.c
+++ b/src/kerberos.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "kerberosbasic.h"
@@ -244,9 +245,9 @@ static PyObject *channelBindings(PyObject *self, PyObject *args, PyObject* keywd
     char *initiator_address = NULL;
     char *acceptor_address = NULL;
     char *application_data = NULL;
-    int initiator_length = 0;
-    int acceptor_length = 0;
-    int application_length = 0;
+    Py_ssize_t initiator_length = 0;
+    Py_ssize_t acceptor_length = 0;
+    Py_ssize_t application_length = 0;
 
     PyObject *pychan_bindings = NULL;
     struct gss_channel_bindings_struct *input_chan_bindings;


### PR DESCRIPTION
Python 3.10 requires that the `Py_ssize_t` type is used for string lengths instead of `int`.
Closes #88.

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
